### PR TITLE
refactor: unify duplicated CSS patterns into globals.css

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -238,6 +238,66 @@ input {
   gap: 0.75rem;
 }
 
+/* ── Navigation row ── */
+.navRow {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  justify-content: space-between;
+}
+
+.navRow button {
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0;
+  flex-shrink: 0;
+}
+
+.navLabel {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+/* ── Table ── */
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid var(--color-main);
+  font-size: 0.9rem;
+}
+
+.table th {
+  font-weight: 700;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-main);
+}
+
+.table tr:last-child td {
+  border-bottom: none;
+}
+
+/* ── Utility ── */
+.emptyMessage {
+  font-style: italic;
+  color: var(--color-main);
+}
+
+.error {
+  color: #c0392b;
+  font-style: italic;
+  font-size: 0.85rem;
+  margin: 0;
+}
+
 @media (min-width: 400px) {
   .pageContainer {
     width: auto;

--- a/src/components/pageComponents/HistoryContent.module.css
+++ b/src/components/pageComponents/HistoryContent.module.css
@@ -1,48 +1,7 @@
-.navRow {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
+.tableContainer {
   width: 100%;
-  justify-content: space-between;
-}
-
-.navRow button {
-  width: 2.5rem;
-  height: 2.5rem;
-  padding: 0;
-  flex-shrink: 0;
-}
-
-.weekLabel {
-  font-size: 1rem;
-  font-weight: 600;
-}
-
-.table {
-  width: 100%;
-  border-collapse: collapse;
   border: var(--border);
   box-shadow: var(--box-shadow);
-}
-
-.table th,
-.table td {
-  padding: 0.5rem 0.75rem;
-  text-align: left;
-  border-bottom: 1px solid var(--color-main);
-  font-size: 0.9rem;
-}
-
-.table th {
-  font-weight: 700;
-  font-size: 0.8rem;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--color-main);
-}
-
-.table tr:last-child td {
-  border-bottom: none;
 }
 
 .words {
@@ -50,9 +9,4 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.emptyMessage {
-  font-style: italic;
-  color: var(--color-main);
 }

--- a/src/components/pageComponents/HistoryContent.tsx
+++ b/src/components/pageComponents/HistoryContent.tsx
@@ -54,11 +54,11 @@ export default function HistoryContent({ initialWords }: HistoryContentProps) {
 
   return (
     <div className="pageContainer">
-      <div className={styles.navRow}>
+      <div className="navRow">
         <button type="button" onClick={() => setWeekOffset(o => o - 1)} aria-label="Previous week">
           ◀
         </button>
-        <span className={styles.weekLabel}>{label}</span>
+        <span className="navLabel">{label}</span>
         <button
           type="button"
           onClick={() => setWeekOffset(o => o + 1)}
@@ -70,28 +70,30 @@ export default function HistoryContent({ initialWords }: HistoryContentProps) {
       </div>
 
       {weekSessions.length === 0 ? (
-        <p className={styles.emptyMessage}>No tests this week</p>
+        <p className="emptyMessage">No tests this week</p>
       ) : (
-        <table className={styles.table}>
-          <thead>
-            <tr>
-              <th>Day</th>
-              <th>Date</th>
-              <th>Words</th>
-              <th>Result</th>
-            </tr>
-          </thead>
-          <tbody>
-            {weekSessions.map(session => (
-              <tr key={session.timestamp}>
-                <td>{formatDay(session.timestamp)}</td>
-                <td>{formatDate(session.timestamp)}</td>
-                <td className={styles.words}>{session.words.map(w => w.word).join(', ')}</td>
-                <td>{`${session.score}/${session.total}`}</td>
+        <div className={styles.tableContainer}>
+          <table className="table">
+            <thead>
+              <tr>
+                <th>Day</th>
+                <th>Date</th>
+                <th>Words</th>
+                <th>Result</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {weekSessions.map(session => (
+                <tr key={session.timestamp}>
+                  <td>{formatDay(session.timestamp)}</td>
+                  <td>{formatDate(session.timestamp)}</td>
+                  <td className={styles.words}>{session.words.map(w => w.word).join(', ')}</td>
+                  <td>{`${session.score}/${session.total}`}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       )}
     </div>
   );

--- a/src/components/pageComponents/MyWordsContent.module.css
+++ b/src/components/pageComponents/MyWordsContent.module.css
@@ -12,13 +12,6 @@
   gap: 0.25rem;
 }
 
-.error {
-  margin: 0;
-  font-style: italic;
-  color: orangered;
-  line-height: normal;
-}
-
 .wordList {
   list-style: none;
   padding: 0;

--- a/src/components/pageComponents/MyWordsContent.tsx
+++ b/src/components/pageComponents/MyWordsContent.tsx
@@ -91,7 +91,7 @@ export default function MyWordsContent({ initialWords }: MyWordsContentProps) {
           />
         </label>
         {formError && (
-          <p className={styles.error} role="alert">
+          <p className="error" role="alert">
             {formError}
           </p>
         )}

--- a/src/components/pageComponents/ProgressContent.module.css
+++ b/src/components/pageComponents/ProgressContent.module.css
@@ -1,23 +1,3 @@
-.navRow {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  width: 100%;
-  justify-content: space-between;
-}
-
-.navRow button {
-  width: 2.5rem;
-  height: 2.5rem;
-  padding: 0;
-  flex-shrink: 0;
-}
-
-.groupLabel {
-  font-size: 1rem;
-  font-weight: 600;
-}
-
 .tableContainer {
   max-height: 70vh;
   overflow-y: auto;
@@ -26,40 +6,13 @@
   box-shadow: var(--box-shadow);
 }
 
-.table {
-  width: 100%;
-  border-collapse: collapse;
-}
-
-.table th,
-.table td {
-  padding: 0.5rem 0.75rem;
-  text-align: left;
-  border-bottom: 1px solid var(--color-main);
-  font-size: 0.9rem;
-}
-
-.table th {
+.tableContainer th {
   position: sticky;
   top: 0;
   background-color: var(--color-main-background);
   z-index: 1;
-  font-weight: 700;
-  font-size: 0.8rem;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--color-main);
-}
-
-.table tr:last-child td {
-  border-bottom: none;
 }
 
 .streak {
   white-space: nowrap;
-}
-
-.emptyMessage {
-  font-style: italic;
-  color: var(--color-main);
 }

--- a/src/components/pageComponents/ProgressContent.tsx
+++ b/src/components/pageComponents/ProgressContent.tsx
@@ -26,7 +26,7 @@ export default function ProgressContent({ initialWords }: ProgressContentProps) 
   if (allGroups.length === 0) {
     return (
       <div className="pageContainer">
-        <p className={styles.emptyMessage}>No words yet.</p>
+        <p className="emptyMessage">No words yet.</p>
       </div>
     );
   }
@@ -35,7 +35,7 @@ export default function ProgressContent({ initialWords }: ProgressContentProps) 
 
   return (
     <div className="pageContainer">
-      <div className={styles.navRow}>
+      <div className="navRow">
         <button
           type="button"
           onClick={() => setViewIndex(v => v - 1)}
@@ -44,7 +44,7 @@ export default function ProgressContent({ initialWords }: ProgressContentProps) 
         >
           ◀
         </button>
-        <span className={styles.groupLabel}>{currentGroup.label}</span>
+        <span className="navLabel">{currentGroup.label}</span>
         <button
           type="button"
           onClick={() => setViewIndex(v => v + 1)}
@@ -56,7 +56,7 @@ export default function ProgressContent({ initialWords }: ProgressContentProps) 
       </div>
 
       <div className={styles.tableContainer}>
-        <table className={styles.table}>
+        <table className="table">
           <thead>
             <tr>
               <th>Word</th>

--- a/src/components/pageComponents/WordListsContent.module.css
+++ b/src/components/pageComponents/WordListsContent.module.css
@@ -1,24 +1,9 @@
-.navRow {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  width: 100%;
-  justify-content: space-between;
-}
-
 .controlsContainer {
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
   width: 100%;
-}
-
-.navRow button {
-  width: 2.5rem;
-  height: 2.5rem;
-  padding: 0;
-  flex-shrink: 0;
 }
 
 .listLabel {
@@ -98,13 +83,6 @@
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
-}
-
-.error {
-  color: #c0392b;
-  font-style: italic;
-  font-size: 0.85rem;
-  margin: 0;
 }
 
 .pendingList {

--- a/src/components/pageComponents/WordListsContent.tsx
+++ b/src/components/pageComponents/WordListsContent.tsx
@@ -159,7 +159,7 @@ function CreateListForm({ allWords, onCancel, onCreated }: CreateListFormProps) 
             />
           </label>
           {newWordError && (
-            <p className={styles.error} role="alert">
+            <p className="error" role="alert">
               {newWordError}
             </p>
           )}
@@ -208,7 +208,7 @@ function CreateListForm({ allWords, onCancel, onCreated }: CreateListFormProps) 
       </div>
 
       {submitError && (
-        <p className={styles.error} role="alert">
+        <p className="error" role="alert">
           {submitError}
         </p>
       )}
@@ -309,7 +309,7 @@ export default function WordListsContent({ initialWordSets, initialWords, initia
     <div className="pageContainer">
       <div className={styles.controlsContainer}>
         {/* Navigation row */}
-        <div className={styles.navRow}>
+        <div className="navRow">
           <button
             type="button"
             onClick={() => setViewIndex(v => v - 1)}


### PR DESCRIPTION
Moves shared `.navRow`, `.navLabel`, `.table`, `.emptyMessage`, and `.error` styles from individual CSS modules into globals.css. Removes duplicated rules from ProgressContent, HistoryContent, WordListsContent, and MyWordsContent modules. Standardises error colour to #c0392b across all pages.

Closes #48

Generated with [Claude Code](https://claude.ai/code)