### PR TITLE
fix: type getMongoDB() return value as Promise<Db>

### DIFF
--- a/src/lib/mongoDB.ts
+++ b/src/lib/mongoDB.ts
@@ -1,6 +1,7 @@
+import { Db } from 'mongodb';
 import client from './mongoClient';
 
-export async function getMongoDB(): Promise<any> {
+export async function getMongoDB(): Promise<Db> {
   if (!process.env.MONGODB_DB) {
     throw new Error('Invalid/Missing environment variable: "MONGODB_DB"');
   }


### PR DESCRIPTION
Replace `Promise<any>` with `Promise<Db>` to enable TypeScript type checking on all database operations throughout the codebase.

Closes #17

Generated with [Claude Code](https://claude.ai/code)